### PR TITLE
added object-assign as an npm dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "components"
   ],
   "dependencies": {
-    "crisper": "^1.1.0"
+    "crisper": "^1.1.0",
+    "object-assign": "^4.0.1"
   },
   "devDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
I was trying to use grunt-crisper but was unable to due to not having object-assign already in my package.json. This should fix that problem for the task itself.
